### PR TITLE
add body.night-mode when extension is enabled

### DIFF
--- a/extension/inject.js
+++ b/extension/inject.js
@@ -13,10 +13,20 @@ function loadCSS(file) {
     // in case this runs before head exists. hmmm.
     head.appendChild(link);
   }
-  const body = document.querySelector("body");
-  if (body) {
-    body.classList.add("night-mode");
+  if (!addBodyCls()) {
+    window.addEventListener("load", () => {
+      addBodyCls();
+    });
   }
+}
+
+function addBodyCls() {
+  const body = document.querySelector("body");
+  if (!body) {
+    return false;
+  }
+  body.classList.add("night-mode");
+  return true;
 }
 
 function unloadCSS(file) {

--- a/extension/inject.js
+++ b/extension/inject.js
@@ -13,6 +13,10 @@ function loadCSS(file) {
     // in case this runs before head exists. hmmm.
     head.appendChild(link);
   }
+  const body = document.querySelector("body");
+  if (body) {
+    body.classList.add("night-mode");
+  }
 }
 
 function unloadCSS(file) {
@@ -20,6 +24,8 @@ function unloadCSS(file) {
   if (cssNode) {
     // this could be called when the thing's already unloaded
     cssNode.parentNode.removeChild(cssNode);
+    const body = document.querySelector("body");
+    body.classList.remove("night-mode");
   }
 }
 

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -267,7 +267,9 @@ input {
   color: #ddd !important;
 }
 
-[class*="ChapterContent_content"] {
+/* contrast required for verses with user background color - exclude verses with background-color */
+[class^="ChapterContent_verse"]:not([style*="background-color"])
+  [class*="ChapterContent_content"] {
   color: #ddd !important;
 }
 

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -545,6 +545,14 @@ h3.css-xu7krs a[target="_self"] {
   fill: #ddd;
 }
 
+.shadow-light-2 {
+  box-shadow: 0px 2px 6px rgb(120 120 120 / 85%);
+}
+/* div[aria-label="Cancel"] */
+.fixed > .flex > .flex svg {
+  color: #ddd;
+}
+
 /* 
 
 Page footer


### PR DESCRIPTION
- body.night-mode used in https://github.com/nmatei/chrome-bible-utilities, allows my extension to also adjust some shadows for better contrast based when this extension is enabled.
- fixed the box shadow for currently selected verse popup.